### PR TITLE
Accept code with a mime type of text/plain

### DIFF
--- a/marketplace/forms.py
+++ b/marketplace/forms.py
@@ -93,7 +93,7 @@ class SasviewModelForm(ModelForm):
 
 class ModelFileForm(ModelForm):
     model_file = ModelFileField(allow_empty_file=False,
-        mimetypes=["text/x-c", "text/x-python"], max_size=50*2**10)
+        mimetypes=["text/x-c", "text/x-python", "text/plain"], max_size=50*2**10)
     class Meta:
         model = ModelFile
         fields = ("model_file",)


### PR DESCRIPTION
Mac OS and Linux don't assign specific mime types to common code extensions, so we need to accept files marked as text/plain