### PR TITLE
Bump version of Chart.js for Chrome

### DIFF
--- a/marketplace/templates/marketplace/model_detail.html
+++ b/marketplace/templates/marketplace/model_detail.html
@@ -26,7 +26,7 @@
     });
 </script>
 {% if model.example_data_json != "[]" %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.2.2/Chart.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.bundle.min.js"></script>
 {% endif %}
 
 {% endblock head %}


### PR DESCRIPTION
Newer Chart.js does not hang Chrome on rendering plots in marketplace.

(only tested on a cut-down local version of the HTML page served by the marketplace, not with the full application)

Closes: #21